### PR TITLE
Fixed up layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -14,15 +14,16 @@
     color: var(--black-font);
     margin: 0 auto;
     column-gap: 1em;
-
+    font-family: 'Inika', sans-serif;
 }
 
 .banner {
     background-color: var(--color3);
-    font-family: 'Courier New', Courier, monospace;
+    font-family: 'Inknut Antiqua', sans-serif;
     font-size: 3em;
     min-height: 2em;
     padding: 0.5em;
+    text-align: center;
 }
 
 .logoimage {
@@ -36,16 +37,16 @@
 
 .first-container {
     background-color: var(--color1);
-    padding: 1em;
+    padding: 1rem;
     text-align: center;
-    
+    font-size: 2.5em;
 }
 
 .second-container {
     background-color: var(--color1);
-    padding: 1em;
+    padding: 1rem;
     text-align: center;
-
+    font-size: 2.5em;
 }
 
 .image1-container {
@@ -68,17 +69,6 @@
     
 }
 
-@media (max-width: 72em) {
-    .monitorpic-container {
-        flex-direction: column;
-    }
-    .image1-container {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-evenly;
-        align-items: center;
-    }
-    }
 
 .third-container {
     text-align: center;
@@ -97,14 +87,15 @@
 .monitorpic-container {
     background-color: var(--color1);
     display:flex;
-    flex-direction: column;
-    flex-flow: row;
+    flex-direction: row;
     border-radius: 2em;
-    
+    overflow: hidden;    
 }
 
 .monitorpic-image { 
-    border-radius: 2em;
+    /* border-radius: 2em; */
+    max-width: 42%;
+    flex-shrink: 0;
 }
 
 .monitorpic-blurb {
@@ -159,6 +150,16 @@
     align-items: center;
 
 }
+
+.firstimagebox,
+.secondimagebox,
+.thirdimagebox,
+.fourthimagebox
+{
+    width: 100%;
+}
+
+
 
 #banner  {
     grid-area: bann;
@@ -301,6 +302,7 @@
         "cree cree cree cree" minmax(2em, auto)
         " .    .    .    .  " minmax(1em, auto)
         "cred cred cred cred" minmax(10em, auto)
+        / 1fr  1fr  1fr  1fr
 
 }
 
@@ -339,6 +341,7 @@
         "cree cree cree cree cree cree cree cree" minmax(2em, auto)
         " .    .    .    .    .    .    .    .  " minmax(1em, auto)
         "cred cred cred cred cred cred cred cred" minmax(10em, auto)
+        / 1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr
     
     }
 }
@@ -375,6 +378,7 @@
         "cree cree cree cree cree cree cree cree cree cree cree cree" minmax(2em, auto)
         " .    .    .    .    .    .    .    .    .    .    .    .  " minmax(1em, auto)
         "cred cred cred cred cred cred cred cred cred cred cred cred" minmax(10em, auto)
+        / 1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr
     
     }
 

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>DES222 - Task 1</title>
-    <link href="https://fonts.googleapis.com/css?family=Inter" rel="stylesheet">
+    <link href="https://fonts.cdnfonts.com/css/inknut-antiqua" rel="stylesheet">
+    <link href="https://fonts.cdnfonts.com/css/inika" rel="stylesheet">
     <link rel="stylesheet" href="index.css">
 </head>
 <body>
     <div class="main-container"> 
         <div class="banner" id="banner">
-            <div class="banner-title"> De-Stress</div> 
-            <div class="banner-subtitle"> Don't Stress!</div> 
+            <div class="banner-title"> De-Stress. Don't Stress!</div> 
         </div>
 
         <div class="logoimage" id="logo-image"> <img class="logo-image1" src="images/app pic.jpg" alt="logo-image"></img></div>


### PR DESCRIPTION
Getting images to fill the grid cells is mostly about adding width: 100% to the image element style. Also added an extra line
 / 1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr  1fr
at the end of the grid-template, which forces the layout grid to have equal width columns (sometimes necessary if the images being laid out in the grid have different sizes). Added in the definitions of the fonts in the design file